### PR TITLE
[테스트 데이터 생성기] CH 2. CLIP 07. 도메인 설계2: mock 데이터의 저장테이블

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/domain/SchemaField.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/SchemaField.java
@@ -3,6 +3,7 @@ package uno.fastcampus.testdata.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import uno.fastcampus.testdata.domain.constant.MockDataType;
 
 @Getter
 @Setter
@@ -10,7 +11,7 @@ import lombok.ToString;
 public class SchemaField {
 
     private String fieldName;
-    private String mockDataType;
+    private MockDataType mockDataType;
     private Integer fieldOrder;
     private Integer blankPercent;
     private String typeOptionJson; // {min: 1, max: 5}

--- a/src/main/java/uno/fastcampus/testdata/domain/constant/MockDataType.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/constant/MockDataType.java
@@ -1,0 +1,40 @@
+package uno.fastcampus.testdata.domain.constant;
+
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MockDataType {
+    STRING(Set.of("minLength", "maxLength", "pattern"), null),
+    NUMBER(Set.of("min", "max", "decimals"), null),
+    BOOLEAN(Set.of(), null),
+    DATETIME(Set.of("from", "to"), null),
+    ENUM(Set.of("elements"), null),
+
+    SENTENCE(Set.of("minSentences", "maxSentences"), STRING),
+    PARAGRAPH(Set.of("minParagraphs", "maxParagraph"), STRING),
+    UUID(Set.of(), STRING),
+    EMAIL(Set.of("from", "to"), STRING),
+    CAR(Set.of("elements"), STRING),
+    ROW_NUMBER(Set.of("start", "stem"), STRING),
+    NAME(Set.of(), STRING);
+
+    private final Set<String> requiredOptions;
+    private final MockDataType baseType;
+
+    public boolean isBaseType() {
+        return baseType == null;
+    }
+
+    public MockDataTypeObject toObject(){
+        return new MockDataTypeObject(
+            this.name(),
+            this.requiredOptions,
+            this.baseType == null ? null : this.baseType.name()
+        );
+    }
+    public record MockDataTypeObject(String name, Set<String> requiredOptions, String baseType) {
+    }
+}

--- a/src/test/java/uno/fastcampus/testdata/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/uno/fastcampus/testdata/domain/constant/MockDataTypeTest.java
@@ -1,0 +1,39 @@
+package uno.fastcampus.testdata.domain.constant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uno.fastcampus.testdata.domain.constant.MockDataType.MockDataTypeObject;
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 이름을 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnsElementName(){
+        // given
+        MockDataType mockDataType = MockDataType.STRING;
+
+        // when
+        String elementName = mockDataType.toString();
+
+        // then
+        System.out.println(elementName);
+        assertThat(elementName).isEqualTo(MockDataType.STRING.name());
+    }
+
+    @DisplayName("자료형이 주어지면, 해당 원소의 데이터를 리턴한다.")
+    @Test
+    void givenMockDataType_whenReading_thenReturnsEnumElementObject(){
+        // given
+        MockDataType mockDataType = MockDataType.STRING;
+
+        // when
+        MockDataType.MockDataTypeObject result = mockDataType.toObject();
+
+        // then
+        assertThat(result.toString())
+            .contains("name","requiredOptions","baseType");
+    }
+}


### PR DESCRIPTION
가짜 데이터 타입은 DB에 저장 관리하지 않기로 함.
따라서 타입을 용이하게 관리할 수 있는 enum 방식을 선택.
enum 정보는 가짜 데이터 생성에 필요한 옵션 정보를 들고 있고,
이를 프론트에도 넘겨줄 수 있도록 하는 방법을 추가로 고민함.
구현한 내용을 간단히 문자열 반환하여 테스트함.