### PR TITLE
mock 데이터 설계하기

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/domain/MockData.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/MockData.java
@@ -3,12 +3,13 @@ package uno.fastcampus.testdata.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import uno.fastcampus.testdata.domain.constant.MockDataType;
 
 @Getter
 @Setter
 @ToString
 public class MockData {
     
-    private String mockDataType;
+    private MockDataType mockDataType;
     private String mockDataValue;
 }

--- a/src/main/java/uno/fastcampus/testdata/domain/MockData.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/MockData.java
@@ -1,0 +1,14 @@
+package uno.fastcampus.testdata.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class MockData {
+    
+    private String mockDataType;
+    private String mockDataValue;
+}


### PR DESCRIPTION
이 작업은 가짜 데이터 중 알고리즘으로 생성하기 적절치 않은 고유명사를 사전식으로 미리 저장해뒀다가 꺼내 쓰기 위해
가짜 데이터 도메인을 설계한다.

This closes #9 