### PR TITLE
테스트용: H2, 인메모리 DB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,6 @@
 spring:
   application.name: test-data
+  datasource.url: jdbc:h2:mem:testdb
   #콘솔 색상 설정
   output:
     ansi:
@@ -21,3 +22,9 @@ logging:
   level:
     uno.fastcampus.testdata: debug
     org.springframework.web.servlet: debug
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE


### PR DESCRIPTION
이 작업은 h2 db 를 사용하도록 스프링 부트 프로퍼티를 추가한다.
또한 테스트 프로파일을 별도 마련하여 mysql 호환성 모드르도 h2 동작시킬 수 있도록 환경을 준비한다.

This closes #19 