### PR TITLE
[테스트 데이터 생성기] CH 2. CLIP 10. 데이터베이스: DB를 표현할 entity 코드의 작성

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/domain/AuditingFields.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/AuditingFields.java
@@ -1,0 +1,41 @@
+package uno.fastcampus.testdata.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    private String createdBy; // 생성자
+
+    @DateTimeFormat(iso = ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false)
+    private String modifiedBy; // 수정자
+}

--- a/src/main/java/uno/fastcampus/testdata/domain/MockData.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/MockData.java
@@ -1,15 +1,71 @@
 package uno.fastcampus.testdata.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import uno.fastcampus.testdata.domain.constant.MockDataType;
 
+/**
+ * 특정 {@link MockDataType}에 대응하는 가짜 데이터.
+ * 알고리즘으로 생성하지 않는 {@link MockDataType}의 경우, 이 가짜 데이터를 랜덤으로 뽑아 출력한다.
+ */
 @Getter
-@Setter
 @ToString
+@Table(uniqueConstraints ={
+    @UniqueConstraint(columnNames = {"mockDataType", "mockDataValue"})
+} )
+@Entity
 public class MockData {
-    
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter @Column(nullable = false)
     private MockDataType mockDataType;
+
+    @Setter @Column(nullable = false)
     private String mockDataValue;
+
+    protected MockData(){}
+
+    public MockData(MockDataType mockDataType, String mockDataValue) {
+        this.mockDataType = mockDataType;
+        this.mockDataValue = mockDataValue;
+    }
+
+    public static MockData of(MockDataType mockDataType, String mockDataValue) {
+        return new MockData(mockDataType, mockDataValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MockData that)) {
+            return false;
+        }
+        if (getId() == null) {
+            return Objects.equals(this.getMockDataType() , that.getMockDataType()) &&
+                Objects.equals(this.getMockDataValue(), that.getMockDataValue());
+        }
+        return Objects.equals(this.getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() == null) {
+            return Objects.hash(getMockDataType(), getMockDataValue());
+        }
+        return Objects.hashCode(getId());
+    }
 }

--- a/src/main/java/uno/fastcampus/testdata/domain/SchemaField.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/SchemaField.java
@@ -1,20 +1,84 @@
 package uno.fastcampus.testdata.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import uno.fastcampus.testdata.domain.constant.MockDataType;
 
+/**
+ * 특정 {@link TableSchema}의 단위 필드 정보.
+ * 이 필드들이 모여서 테이블 스키마를 구성한다
+ */
 @Getter
-@Setter
-@ToString
-public class SchemaField {
+@ToString(callSuper = true)
+@Entity
+public class SchemaField extends AuditingFields{
 
-    private String fieldName;
-    private MockDataType mockDataType;
-    private Integer fieldOrder;
-    private Integer blankPercent;
-    private String typeOptionJson; // {min: 1, max: 5}
-    private String forceValue;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
+    @Setter
+    @ManyToOne(optional = false) // nullable 하지 않다
+    private TableSchema tableSchema;
+
+    @Setter private @Column(nullable = false) String fieldName;
+    @Setter private @Column(nullable = false) MockDataType mockDataType;
+    @Setter private @Column(nullable = false) Integer fieldOrder;
+    @Setter private @Column(nullable = false) Integer blankPercent;
+    @Setter private String typeOptionJson; // {min: 1, max: 5}
+    @Setter private String forceValue;
+
+    protected SchemaField() {
+    }
+
+    public SchemaField(String fieldName, MockDataType mockDataType, Integer fieldOrder,
+        Integer blankPercent, String typeOptionJson, String forceValue) {
+        this.fieldName = fieldName;
+        this.mockDataType = mockDataType;
+        this.fieldOrder = fieldOrder;
+        this.blankPercent = blankPercent;
+        this.typeOptionJson = typeOptionJson;
+        this.forceValue = forceValue;
+    }
+
+    public static SchemaField of(String fieldName, MockDataType mockDataType, Integer fieldOrder,
+        Integer blankPercent, String typeOptionJson, String forceValue) {
+        return new SchemaField(fieldName, mockDataType, fieldOrder, blankPercent, typeOptionJson,
+            forceValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SchemaField that)) return false;
+
+        if (this.getId() == null) {
+            return Objects.equals(this.getTableSchema().getId(), that.getTableSchema().getId()) &&
+                Objects.equals(this.getMockDataType(), that.getMockDataType()) &&
+                Objects.equals(this.getFieldName(), that.getFieldName()) &&
+                Objects.equals(this.getFieldOrder(), that.getFieldOrder()) &&
+                Objects.equals(this.getBlankPercent(), that.getBlankPercent()) &&
+                Objects.equals(this.getTypeOptionJson(), that.getTypeOptionJson()) &&
+                Objects.equals(this.getForceValue(), that.getForceValue());
+        }
+
+        return Objects.equals(this.getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() == null) {
+            return Objects.hash(getTableSchema().getId(), getMockDataType(), getFieldName(), getFieldOrder(), getBlankPercent(), getTypeOptionJson(), getForceValue());
+        }
+
+        return Objects.hash(getId());
+    }
 }

--- a/src/main/java/uno/fastcampus/testdata/domain/TableSchema.java
+++ b/src/main/java/uno/fastcampus/testdata/domain/TableSchema.java
@@ -1,18 +1,99 @@
 package uno.fastcampus.testdata.domain;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * 단위 테이블 스키마 정보.
+ * 식별자 ({@link #userId})로 특정할 수 있는 회원이 소유한다.
+ */
 @Getter
-@Setter
-@ToString
-public class TableSchema {
+@ToString(callSuper = true)
+@Entity
+public class TableSchema extends AuditingFields{
 
-    private String schemaName;
-    private String userId;
-    private LocalDateTime exportedAt; // 출력이 되었는지?
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter private String schemaName;
+    @Setter private String userId;
+    @Setter private LocalDateTime exportedAt; // 출력이 되었는지?
 
 
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "tableSchema", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final Set<SchemaField> schemaFields = new LinkedHashSet<>();
+
+    protected TableSchema(){}
+
+    public TableSchema(String schemaName, String userId) {
+        this.schemaName = schemaName;
+        this.userId = userId;
+        this.exportedAt = null;
+    }
+
+    public static TableSchema of(String schemaName, String userId) {
+        return new TableSchema(schemaName, userId);
+    }
+
+    public void markExported(){
+        exportedAt = LocalDateTime.now();
+    }
+
+    public boolean isExported(){
+        return exportedAt != null;
+    }
+
+    public void addSchemaField(SchemaField schemaField) {
+        schemaField.setTableSchema(this);
+        schemaFields.add(schemaField);
+    }
+
+    public void addSchemaFields(Collection<SchemaField> schemaFields) {
+        schemaFields.forEach(this::addSchemaField);
+    }
+
+    public void clearSchemaFields(){
+        schemaFields.clear();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TableSchema that)) {
+            return false;
+        }
+        if (that.getId() == null) {
+            return Objects.equals(getSchemaName(), that.getSchemaName()) &&
+                Objects.equals(getUserId(), that.getUserId()) &&
+                Objects.equals(getExportedAt(), that.getExportedAt()) &&
+                Objects.equals(getSchemaFields(), that.getSchemaFields());
+        }
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        if (getId() == null) {
+            return Objects.hash(getSchemaName(), getUserId(), getExportedAt(),
+                getSchemaFields());
+        }
+        return Objects.hash(getId());
+    }
 }


### PR DESCRIPTION
각 도메인이 실제로 JPA 를 통해 db에 접근할 수 있도록 엔티티 연관 정보를 추가 및 엔티티 추상클래스 추가