### PR TITLE
스프링 시큐리티 의존성 삭제하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+	/*implementation 'org.springframework.boot:spring-boot-starter-security'*/
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'


### PR DESCRIPTION
#5  강의 속에서, Spring Security와 OAuth2 Client를 둘 다 써서 프로젝트를 셋업하고 Security를 지우려고 했었다.
그러나 강의 흐름 중에 이를 하지 않았다.
별도로 삭제 처리하도록 한다.

참고로 이렇게 두 의존성을 넣고 나중에 시큐리티 의존성을 빼는 이유는 시큐리티에 추가로 따라오는 의존성들을 자연스럽게 받기 위해서였는데,
이제 이 문제가 해결되어 이렇게 번거롭게 할 필요가 없어졌다. 자세한 내용은 레퍼런스 링크 참고.
앞으로는 Oauth 2.0, Thymeleaf 기술만 쓰려고 한다면 편하게 그냥 `Oauth2 Client` + `Thymeleaf` 의존성만 추가하는 것으로 정상 동작한다.

this closes #5 
